### PR TITLE
Enough to have transitive (via js) dependency on truffle-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,12 +140,6 @@
             <version>${graalvm.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.truffle</groupId>
-            <artifactId>truffle-api</artifactId>
-            <version>${graalvm.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.graalvm.js</groupId>
             <artifactId>js</artifactId>
             <version>${graalvm.version}</version>


### PR DESCRIPTION
@boris-spas pointed out, that this dependency is redundant. Removing.