### PR TITLE
Test also on openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 language: java
 
 jdk:
+    - openjdk8
     - openjdk11
 
 env:
@@ -18,6 +19,7 @@ install:
         tar -xzf graalvm.tar.gz
 
 script:
+    - java -version
     - mvn clean
     - mvn package
     - mvn exec:exec


### PR DESCRIPTION
I believe it is desirable to make sure the project can be *compiled* on any JDK8. That also removes the need for special configuration of JDK in the IDEs when the project is opened.

First of all let's enable testing on JDK8.