### PR TITLE
Giving the script a name

### DIFF
--- a/src/main/java/com/mycompany/app/App.java
+++ b/src/main/java/com/mycompany/app/App.java
@@ -6,6 +6,7 @@ import javax.script.ScriptEngineManager;
 import javax.script.ScriptEngine;
 import javax.script.Invocable;
 import java.io.IOException;
+import org.graalvm.polyglot.Source;
 
 /**
  * Simple benchmark for Graal.js via GraalVM Polyglot Context and ScriptEngine.
@@ -80,7 +81,7 @@ public class App {
         System.out.println("=== Graal.js via org.graalvm.polyglot.Context === ");
         long took = 0;
         try (Context context = Context.create()) {
-            context.eval("js", SOURCE);
+            context.eval(Source.newBuilder("js", SOURCE, "src.js").build());
             Value primesMain = context.getBindings("js").getMember("primesMain");
             System.out.println("warming up ...");
             for (int i = 0; i < WARMUP; i++) {


### PR DESCRIPTION
When debugging on [GraalVM](http://graalvm.org) 1.0.0rc9 and in [NetBeans](http://apache.netbeans.org) 10 I don't see the `SOURCE` as JavaScript. Probably because it is `Unnamed` without any extension. Giving it `app.js` name fixes the problem.

To reproduce start NetBeans 10 as:
```bash
graal-js-jdk11-maven-demo$ netbeans --jdkhome /graalvm/ --userdir /tmp/gvmud .
```
put breakpoint before `eval` and invoke _Debug Project_ action. Once the breakpoint (in Java code) is hit, use the new _Toggle pause in GraalVM script_ action in debugger toolbar and once enabled, _Continue_. The execution stops at first line of your *JavaScript*. Since then your mixed *Java+JavaScript* debugging becomes reality, but it is better to see the source as JavaScript than unnamed one. For example the former allows one to add JavaScript breakpoints.

CC @entlicher, @geertjanw as this could be very nice demo showing how OracleLabs contribute to polyglot features of the IDE once **NetBeans 10** is out.